### PR TITLE
Remove moniker_ranges from op config

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -6,10 +6,7 @@
       "build_output_subfolder": "botbuilder-typescript",
       "locale": "en-us",
       "monikers": [],
-      "moniker_ranges": [
-        "botbuilder-ts-latest",
-        "botbuilder-ts-3.0"
-	  ],
+      "moniker_ranges": [],
       "open_to_public_contributors": true,
       "type_mapping": {
         "Conceptual": "Content",

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -5,7 +5,10 @@
       "build_source_folder": "botbuilder-typescript",
       "build_output_subfolder": "botbuilder-typescript",
       "locale": "en-us",
-      "monikers": [],
+      "monikers": [
+        "botbuilder-ts-latest",
+        "botbuilder-ts-3.0"
+      ],
       "moniker_ranges": [],
       "open_to_public_contributors": true,
       "type_mapping": {


### PR DESCRIPTION
The docset is using monikers instead of moniker_ranges, thus removing from op config. Otherwise the moniker_ranges setting confused underlying system.

@JiayueHu - could you please help review this PR?