### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

### DIFF
--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/ExpressionFunctions.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/ExpressionFunctions.yml
@@ -7,7 +7,7 @@ summary: |-
    Definition of default built-in functions for expressions.
    </summary>
    <remarks>
-   These functions are largely from WDL https://docs.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
+   These functions are largely from WDL https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
    with a few extensions like infix operators for math, logic and comparisons.
    This class also has some methods that are useful to use when defining custom functions.
    You can always construct a <see cref="ExpressionEvaluator"/> directly which gives the maximum amount of control over validation and evaluation.

--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/ExpressionFunctions.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/ExpressionFunctions.yml
@@ -7,7 +7,7 @@ summary: |-
    Definition of default built-in functions for expressions.
    </summary>
    <remarks>
-   These functions are largely from WDL https://learn.microsoft.com/en-us/azure/logic-apps/workflow-definition-language-functions-reference
+   These functions are largely from [WDL](/azure/logic-apps/workflow-definition-language-functions-reference)
    with a few extensions like infix operators for math, logic and comparisons.
    This class also has some methods that are useful to use when defining custom functions.
    You can always construct a <see cref="ExpressionEvaluator"/> directly which gives the maximum amount of control over validation and evaluation.

--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/FormatDateTime.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/FormatDateTime.yml
@@ -5,8 +5,7 @@ package: adaptive-expressions
 summary: >-
   Return a timestamp in the specified format.
 
-  Format reference:
-  https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+  For more information, see [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings).
 fullName: FormatDateTime
 remarks: ''
 isPreview: false

--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/FormatDateTime.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/FormatDateTime.yml
@@ -6,7 +6,7 @@ summary: >-
   Return a timestamp in the specified format.
 
   Format reference:
-  https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+  https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
 fullName: FormatDateTime
 remarks: ''
 isPreview: false

--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/index.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/index.yml
@@ -269,8 +269,7 @@ functions:
     package: adaptive-expressions
     summary: >-
       Convert a CSharp style datetime format string to a Day.js style datetime
-      format string. Ref:
-      https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+      format string. For more information, see [Custom date and time format strings](/dotnet/standard/base-types/custom-date-and-time-format-strings).
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/index.yml
+++ b/botbuilder-typescript/docs-ref-autogen/adaptive-expressions/index.yml
@@ -270,7 +270,7 @@ functions:
     summary: >-
       Convert a CSharp style datetime format string to a Day.js style datetime
       format string. Ref:
-      https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
+      https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/botbuilder-typescript/docs-ref-autogen/botbuilder-azure/CosmosDbKeyEscape.yml
+++ b/botbuilder-typescript/docs-ref-autogen/botbuilder-azure/CosmosDbKeyEscape.yml
@@ -15,7 +15,7 @@ functions:
       property: '/', '\', '?', '#'
 
       More information at
-      https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
+      https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/botbuilder-typescript/docs-ref-autogen/botbuilder-azure/CosmosDbKeyEscape.yml
+++ b/botbuilder-typescript/docs-ref-autogen/botbuilder-azure/CosmosDbKeyEscape.yml
@@ -14,8 +14,7 @@ functions:
       The following characters are restricted and cannot be used in the Id
       property: '/', '\', '?', '#'
 
-      More information at
-      https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks
+      For more information, see [Resource.Id Property](dotnet/api/microsoft.azure.documents.resource.id?#remarks).
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/botbuilder-typescript/docs-ref-autogen/botbuilder-core/BotAdapter.yml
+++ b/botbuilder-typescript/docs-ref-autogen/botbuilder-core/BotAdapter.yml
@@ -37,9 +37,9 @@ remarks: >-
   For more information, see the articles on
 
   [How bots
-  work](https://docs.microsoft.com/azure/bot-service/bot-builder-basics) and
+  work](/azure/bot-service/bot-builder-basics) and
 
-  [Middleware](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-middleware).
+  [Middleware](/azure/bot-service/bot-builder-concept-middleware).
 isPreview: false
 isDeprecated: false
 type: class

--- a/botbuilder-typescript/docs-ref-autogen/botbuilder-dialogs/DialogState.yml
+++ b/botbuilder-typescript/docs-ref-autogen/botbuilder-dialogs/DialogState.yml
@@ -16,11 +16,11 @@ remarks: >-
   For more information, see the articles on
 
   [Managing
-  state](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-state)
+  state](/azure/bot-service/bot-builder-concept-state)
   and
 
   [Dialogs
-  library](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-dialog).
+  library](/azure/bot-service/bot-builder-concept-dialog).
 isPreview: false
 isDeprecated: false
 type: interface

--- a/botbuilder-typescript/docs-ref-autogen/botbuilder/BotFrameworkAdapter.yml
+++ b/botbuilder-typescript/docs-ref-autogen/botbuilder/BotFrameworkAdapter.yml
@@ -1221,9 +1221,9 @@ methods:
       For more information about the middleware pipeline, see the
 
       [how bots
-      work](https://docs.microsoft.com/azure/bot-service/bot-builder-basics) and
+      work](/azure/bot-service/bot-builder-basics) and
 
-      [middleware](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-middleware)
+      [middleware](/azure/bot-service/bot-builder-concept-middleware)
       articles.
 
       Use the adapter's [use](xref:botbuilder-core.BotAdapter.use) method to add
@@ -1296,9 +1296,9 @@ methods:
       For more information about the middleware pipeline, see the
 
       [how bots
-      work](https://docs.microsoft.com/azure/bot-service/bot-builder-basics) and
+      work](/azure/bot-service/bot-builder-basics) and
 
-      [middleware](https://docs.microsoft.com/azure/bot-service/bot-builder-concept-middleware)
+      [middleware](/azure/bot-service/bot-builder-concept-middleware)
       articles.
 
       Use the adapter's [use](xref:botbuilder-core.BotAdapter.use) method to add


### PR DESCRIPTION
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute

**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
